### PR TITLE
fix: Update Github Actions Firebase Tools version

### DIFF
--- a/.github/workflows/firebase-hosting-merge-staging.yml
+++ b/.github/workflows/firebase-hosting-merge-staging.yml
@@ -18,6 +18,6 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GEOSHIP_A16BD }}'
           channelId: staging
           projectId: geoship-a16bd
-          firebaseToolsVersion: "10.7.0"
+          firebaseToolsVersion: "13.11.2"
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks


### PR DESCRIPTION
The initial value came from the terminal configuration, but the last successful build was a month ago. Therefore, the new selected version is from one month ago. This will be tested through Github Actions