### PR TITLE
fix: Added Firebase Tools version to all actions

### DIFF
--- a/.github/workflows/firebase-hosting-merge-main.yml
+++ b/.github/workflows/firebase-hosting-merge-main.yml
@@ -18,5 +18,6 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GEOSHIP_A16BD }}'
           channelId: live
           projectId: geoship-a16bd
+          firebaseToolsVersion: "13.11.2"
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks


### PR DESCRIPTION
Previously, only staging's action got modified with a static version during testing. Now, all github actions have a firebase tools version. This has been tested with staging's github actions.

GEO-35